### PR TITLE
refactor(worker): implement immediate retry in same worker

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -118,9 +118,7 @@ func (m *Manager[T]) next() {
 	m.logger.Debug("got task", slog.String("id", task.GetID()))
 	go func() {
 		defer func() {
-			if task.GetState() == StateWaitingRetry {
-				m.toRunTaskQueue.Push(task)
-			}
+			// Execute() handles all retries in the same worker, task is completed when it returns
 			m.workers.Put(worker)
 			m.next()
 		}()

--- a/worker.go
+++ b/worker.go
@@ -26,38 +26,34 @@ func (w Worker) Execute(task Task) {
 			}
 		}
 		
+		onError := func(err error) {
+			task.SetErr(err)
+			if errors.Is(err, context.Canceled) {
+				task.SetState(StateCanceled)
+			} else {
+				task.SetState(StateErrored)
+			}
+			if !needRetry(task) {
+				if hook, ok := Task(task).(OnFailed); ok {
+					task.SetState(StateFailing)
+					hook.OnFailed()
+				}
+				task.SetState(StateFailed)
+			}
+		}
+		
 		func() {
 			defer func() {
 				if err := recover(); err != nil {
 					log.Printf("error [%s] while run task [%s],stack trace:\n%s", err, task.GetID(), getCurrentGoroutineStack())
-					task.SetErr(NewErr(fmt.Sprintf("panic: %v", err)))
-					task.SetState(StateErrored)
-					if !needRetry(task) {
-						if hook, ok := Task(task).(OnFailed); ok {
-							task.SetState(StateFailing)
-							hook.OnFailed()
-						}
-						task.SetState(StateFailed)
-					}
+					onError(NewErr(fmt.Sprintf("panic: %v", err)))
 				}
 			}()
 			
 			task.SetState(StateRunning)
 			err := task.Run()
 			if err != nil {
-				task.SetErr(err)
-				if errors.Is(err, context.Canceled) {
-					task.SetState(StateCanceled)
-					return
-				}
-				task.SetState(StateErrored)
-				if !needRetry(task) {
-					if hook, ok := Task(task).(OnFailed); ok {
-						task.SetState(StateFailing)
-						hook.OnFailed()
-					}
-					task.SetState(StateFailed)
-				}
+				onError(err)
 				return
 			}
 			

--- a/worker.go
+++ b/worker.go
@@ -17,44 +17,62 @@ type Worker struct {
 // Execute executes the task
 func (w Worker) Execute(task Task) {
 	task.SetWorker(&w)
-	if isRetry(task) {
-		task.SetState(StateBeforeRetry)
-		if hook, ok := Task(task).(OnBeforeRetry); ok {
-			hook.OnBeforeRetry()
-		}
-	}
-	onError := func(err error) {
-		task.SetErr(err)
-		if errors.Is(err, context.Canceled) {
-			task.SetState(StateCanceled)
-		} else {
-			task.SetState(StateErrored)
-		}
-		if !needRetry(task) {
-			if hook, ok := Task(task).(OnFailed); ok {
-				task.SetState(StateFailing)
-				hook.OnFailed()
+	// Retry immediately in the same worker until success or max retry exhausted
+	for {
+		if isRetry(task) {
+			task.SetState(StateBeforeRetry)
+			if hook, ok := Task(task).(OnBeforeRetry); ok {
+				hook.OnBeforeRetry()
 			}
-			task.SetState(StateFailed)
+		}
+		
+		func() {
+			defer func() {
+				if err := recover(); err != nil {
+					log.Printf("error [%s] while run task [%s],stack trace:\n%s", err, task.GetID(), getCurrentGoroutineStack())
+					task.SetErr(NewErr(fmt.Sprintf("panic: %v", err)))
+					task.SetState(StateErrored)
+					if !needRetry(task) {
+						if hook, ok := Task(task).(OnFailed); ok {
+							task.SetState(StateFailing)
+							hook.OnFailed()
+						}
+						task.SetState(StateFailed)
+					}
+				}
+			}()
+			
+			task.SetState(StateRunning)
+			err := task.Run()
+			if err != nil {
+				task.SetErr(err)
+				if errors.Is(err, context.Canceled) {
+					task.SetState(StateCanceled)
+					return
+				}
+				task.SetState(StateErrored)
+				if !needRetry(task) {
+					if hook, ok := Task(task).(OnFailed); ok {
+						task.SetState(StateFailing)
+						hook.OnFailed()
+					}
+					task.SetState(StateFailed)
+				}
+				return
+			}
+			
+			task.SetState(StateSucceeded)
+			if onSucceeded, ok := Task(task).(OnSucceeded); ok {
+				onSucceeded.OnSucceeded()
+			}
+			task.SetErr(nil)
+		}()
+		
+		state := task.GetState()
+		if state == StateSucceeded || state == StateCanceled || state == StateFailed {
+			return
 		}
 	}
-	defer func() {
-		if err := recover(); err != nil {
-			log.Printf("error [%s] while run task [%s],stack trace:\n%s", err, task.GetID(), getCurrentGoroutineStack())
-			onError(NewErr(fmt.Sprintf("panic: %v", err)))
-		}
-	}()
-	task.SetState(StateRunning)
-	err := task.Run()
-	if err != nil {
-		onError(err)
-		return
-	}
-	task.SetState(StateSucceeded)
-	if onSucceeded, ok := Task(task).(OnSucceeded); ok {
-		onSucceeded.OnSucceeded()
-	}
-	task.SetErr(nil)
 }
 
 // WorkerPool is the pool of workers


### PR DESCRIPTION
修改了任务执行的逻辑

目前同一个任务会在同一个worker完成,包含重试

这有利于任务在失败时可以使用缓存数据

## Summary by Sourcery

Implement immediate retry logic in Worker.Execute to keep retries within the same worker and simplify Manager to no longer requeue tasks for retry

Enhancements:
- Refactor Worker.Execute to retry tasks in a loop until success, cancellation, or max retries within the same worker
- Remove deferred requeue logic in Manager.next as retries are now handled inside the worker